### PR TITLE
T-1915 README.md: Make sure template is publicly accessible after rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ gcloud dataflow flex-template build gs://betterstack/pubsub-to-betterstack.json 
     --image "docker.io/betterstack/gcp-dataflow-pubsub-to-betterstack" \
     --sdk-language "PYTHON" \
     --metadata-file "metadata.json"
+gsutil iam ch allUsers:roles/storage.legacyObjectReader gs://betterstack/pubsub-to-betterstack.json
 ```
 
 Requires access to `betterstack` Docker Hub repository, and `betterstack` Google Cloud Bucket.


### PR DESCRIPTION
Running `gcloud dataflow flex-template build` resets the IAM of the template JSON file, needs to be changed afterwards to keep it publicly available.