### PR TITLE
Allow dashes in ingesting host

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
       "label": "Better Stack Ingesting Host",
       "helpText": "The ingesting host of your telemetry source in Better Stack.",
       "isOptional": false,
-      "regexes": ["^([a-zA-Z][a-zA-Z0-9]*\\.)+[a-zA-Z]+$"]
+      "regexes": ["^([a-zA-Z][a-zA-Z0-9-]*\\.)+[a-zA-Z]+$"]
     },
     {
       "name": "batch_size",


### PR DESCRIPTION
Originally tested with ingesting host `s1266784.g2.betterstackdata.com` without any dashes.

This PR will allow hosts such as `s1271076.eu-nbg-2.betterstackdata.com`.

Already updated the template in https://storage.cloud.google.com/betterstack/pubsub-to-betterstack.json